### PR TITLE
Fix scrolling page when table is done scrolling

### DIFF
--- a/src/components/media-table/media-table.module.css
+++ b/src/components/media-table/media-table.module.css
@@ -1,6 +1,5 @@
 .tableHeader {
   background-color: var(--mantine-color-white);
-  /* background-color: var(--mantine-color-body); */
   position: sticky;
   top: 0;
   /* Need to provide z-index to be above the checkboxes */

--- a/src/components/media-table/media-table.tsx
+++ b/src/components/media-table/media-table.tsx
@@ -36,7 +36,7 @@ export function MediaTable(props: TableProps) {
 
   return (
     <ScrollArea
-      h={2000}
+      h={0.8 * window.innerHeight}
       onScrollPositionChange={({ y }) => setScrolled(y !== 0)}
     >
       <Table>


### PR DESCRIPTION
* **Fixed** an issue where once the library table was done scrolling the page would keep scrolling removing the sticky header