### PR TITLE
Initial step towards bulk edit

### DIFF
--- a/src/components/media-table/media-table.tsx
+++ b/src/components/media-table/media-table.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { IconEdit } from '@tabler/icons-react';
 import { useNavigate } from 'react-router-dom';
 import { ActionIcon, Flex, Group, Table as MantineTable, Pagination } from '@mantine/core';
@@ -52,6 +52,14 @@ export function MediaTable({ pagination, items, filteredItems, ...props }: Table
     }
   }, [containerRef.current]);
 
+  const navigateToEdit = useCallback(
+    (ids: string[]) =>
+      navigate(
+        `${routeEdit.replace(LIBRARY_MEDIA_ID_PARAM, props.mediaType)}?ids=${ids.join(',')}`
+      ),
+    [props.mediaType, navigate]
+  );
+
   return (
     <Flex direction="column" gap="md" ref={containerRef}>
       <MantineTable.ScrollContainer minWidth={500} maxHeight={containerHeight}>
@@ -74,11 +82,7 @@ export function MediaTable({ pagination, items, filteredItems, ...props }: Table
                 variant="outline"
                 color=""
                 size="sm"
-                onClick={() =>
-                  navigate(
-                    `${routeEdit.replace(LIBRARY_MEDIA_ID_PARAM, props.mediaType)}?ids=${f.id}`
-                  )
-                }
+                onClick={() => navigateToEdit([f.id])}
               >
                 <IconEdit></IconEdit>
               </ActionIcon>
@@ -101,6 +105,10 @@ export function MediaTable({ pagination, items, filteredItems, ...props }: Table
             {
               label: 'Play Selection',
               handler: () => props.onSelectionAction(TableSelectionAction.Play),
+            },
+            {
+              label: 'Edit',
+              handler: () => navigateToEdit(props.selectedItems),
             },
           ]}
         ></Table>

--- a/src/pages/edit/edit.tsx
+++ b/src/pages/edit/edit.tsx
@@ -2,12 +2,12 @@ import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useNavigateMediaLibrary } from '@/hooks/navigation/use-navigate-media-library';
 import { mediaService } from '@/services/media/media-service';
-import { EditItemForm } from './form';
+import { SingleItemEditForm } from './form/single-item-edit-form';
 
 export const EditPage = () => {
   const [searchParams] = useSearchParams();
   const ids = searchParams.get('ids');
-  const [item, setItem] = useState<MediaItemWithNodeId | null>(null);
+  const [items, setItems] = useState<MediaItemWithNodeId[] | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -32,18 +32,19 @@ export const EditPage = () => {
 
       const mediaIds = ids?.split(',');
 
-      mediaService.getMediaByIds(mediaIds).then((items) => setItem(items[0]));
+      mediaService.getMediaByIds(mediaIds).then((items) => setItems(items));
     } else {
       navigateToLibrary(getMediaType());
     }
   }, [ids]);
 
-  if (!item) return <div>Loading...</div>;
+  if (!items) return <div>Loading...</div>;
 
-  return (
-    <div>
-      <h1>{item.name}</h1>
-      <EditItemForm item={item} />
-    </div>
-  );
+  if (items.length === 1)
+    return (
+      <div>
+        <h1>{items[0].name}</h1>
+        <SingleItemEditForm item={items[0]} />
+      </div>
+    );
 };

--- a/src/pages/edit/form/edit-item-form.tsx
+++ b/src/pages/edit/form/edit-item-form.tsx
@@ -1,130 +1,18 @@
-import { useMemo, useState } from 'react';
-import { IconAlertCircle } from '@tabler/icons-react';
-import { useNavigate } from 'react-router-dom';
-import {
-  Button,
-  FileInput,
-  Flex,
-  Group,
-  MantineComponent,
-  NumberInput,
-  TextInput,
-} from '@mantine/core';
-import { isInRange, isNotEmpty, useForm, UseFormInput } from '@mantine/form';
-import { notifications } from '@mantine/notifications';
-import { usePollCompletion } from '@/hooks/use-poll-completion/use-poll-completion';
-import { changesetService } from '@/services/changeset/changeset-service';
-import { mediaService } from '@/services/media/media-service';
-
-const NUMBER_FIELDS = ['trackOf', 'trackIndex'];
-const FILE_FIELDS = ['art'];
+import { FileInput, Flex, MantineComponent, NumberInput, TextInput } from '@mantine/core';
+import { UseFormReturnType } from '@mantine/form';
+import { FILE_FIELDS, NUMBER_FIELDS } from './single-item-edit-form';
 
 interface EditItemFormProps {
-  item: MediaItemWithNodeId;
+  form: UseFormReturnType<{
+    [key: string]: any;
+  }>;
+  dependentsConfig: { [key: string]: string[] };
+  onSubmit: ({ values }: { [key: string]: any }) => Promise<any>;
 }
 
-export const EditItemForm = ({ item }: EditItemFormProps) => {
-  const formConfig = useMemo(() => getFormConfig(item), [item]);
-  const [changesetId, setChangesetId] = useState<null | string>(null);
-  const navigate = useNavigate();
-
-  usePollCompletion({
-    queryCompletion: async () => {
-      if (!changesetId) return { complete: false };
-      try {
-        const changeset = await changesetService.getChangeset(changesetId);
-
-        if (changeset.status === 'complete') return { complete: true, success: true };
-        if (changeset.status === 'failed') return { complete: true };
-
-        return { complete: false };
-      } catch (e) {
-        return { complete: true, success: false };
-      }
-    },
-    onComplete(success) {
-      if (success) {
-        notifications.show({
-          title: 'Updated',
-          message: 'Successfully updated item',
-          autoClose: 2000,
-        });
-      } else {
-        notifications.show({
-          title: 'Failed to edit',
-          message: 'An error occured when trying to edit this item.',
-          autoClose: 5000,
-          color: 'red',
-          icon: <IconAlertCircle></IconAlertCircle>,
-        });
-      }
-
-      setChangesetId(null);
-    },
-    enabled: !!changesetId,
-  });
-
-  if (!formConfig) return <div>Cannot edit item with extenstion {item.extension}</div>;
-  const form = useForm(formConfig);
-
-  const dependencyMappingForMediaType = useMemo(() => getFormDependentsConfig(item), [item]);
-
-  const handleSubmitForm = async (values: { [key: string]: any }) => {
-    const { id: mediaId, nodeId } = item;
-
-    const files = Object.keys(values).reduce<{ fieldName: string; file: any }[]>(
-      (acc, fieldName) => {
-        if (FILE_FIELDS.includes(fieldName)) {
-          const value = values[fieldName];
-          if (value) {
-            acc = [...acc, { fieldName, file: value }];
-          }
-        }
-
-        return acc;
-      },
-      []
-    );
-
-    const change = Object.entries(values).reduce<{ [key: string]: any }>((acc, [key, value]) => {
-      if (NUMBER_FIELDS.includes(key)) {
-        acc[key] = +value;
-      } else if (FILE_FIELDS.includes(key)) {
-        // Save images as the name of the field as that is what is being sent as part of the FormData
-        acc[key] = key;
-      } else {
-        acc[key] = value;
-      }
-
-      return acc;
-    }, {});
-
-    const changes = [
-      {
-        mediaId,
-        nodeId,
-        change,
-      },
-    ];
-
-    try {
-      const changeset = await mediaService.updateMedia(changes, files);
-      setChangesetId(changeset.id);
-
-      form.resetTouched();
-    } catch (e) {
-      notifications.show({
-        title: 'Failed to edit',
-        message: 'An error occured when trying to edit this item.',
-        autoClose: 5000,
-        color: 'red',
-        icon: <IconAlertCircle></IconAlertCircle>,
-      });
-    }
-  };
-
+export const EditItemForm = ({ form, dependentsConfig, onSubmit }: EditItemFormProps) => {
   return (
-    <form onSubmit={form.onSubmit(handleSubmitForm)}>
+    <form>
       <Flex direction="column">
         {Object.keys(form.getValues()).map((fieldName) => {
           const C = getFormField(fieldName);
@@ -138,26 +26,13 @@ export const EditItemForm = ({ item }: EditItemFormProps) => {
               onChange={(e: any) => {
                 fieldBaseProps.onChange(e);
 
-                for (const dep of dependencyMappingForMediaType[fieldName] || []) {
+                for (const dep of dependentsConfig[fieldName] || []) {
                   form.validateField(dep);
                 }
               }}
             />
           );
         })}
-        <Group>
-          <Button mt="md" variant="subtle" onClick={() => navigate(-1)}>
-            Cancel
-          </Button>
-          <Button
-            mt="md"
-            disabled={!form.isValid() || !form.isTouched()}
-            loading={!!changesetId}
-            type="submit"
-          >
-            Save
-          </Button>
-        </Group>
       </Flex>
     </form>
   );
@@ -175,108 +50,4 @@ const getFormField = (fieldName: string) => {
   }
 
   return fieldComponent;
-};
-
-const getFormConfig = (item: MediaItemWithNodeId) => {
-  let config: UseFormInput<{ [key: string]: any }> | null = null;
-
-  if (item.extension === 'mp3') {
-    // TODO: add album art and start/end time
-    config = {
-      mode: 'uncontrolled',
-      validateInputOnChange: true,
-      initialValues: {
-        art: null,
-        name: getValueFromItem('name', item),
-        album: getValueFromItem('album', item),
-        artist: getValueFromItem('artist', item),
-        trackIndex: getValueFromItem('trackIndex', item) || '',
-        trackOf: getValueFromItem('trackOf', item) || '',
-      },
-
-      enhanceGetInputProps({ field: fieldName }) {
-        switch (fieldName) {
-          case 'art': {
-            return {
-              label: 'Album Art',
-              clearable: true,
-              accept: 'image/jpeg,image/jpg',
-              placeholder: 'Upload Album Art',
-            };
-          }
-          case 'name':
-            return {
-              label: 'Song Name',
-              withAsterisk: true,
-            };
-          case 'album':
-            return {
-              label: 'Album',
-              withAsterisk: true,
-            };
-          case 'artist':
-            return {
-              label: 'Artist',
-              withAsterisk: true,
-            };
-          case 'trackIndex':
-            return {
-              label: 'Track Number',
-            };
-          case 'trackOf':
-            return {
-              label: 'Total Tracks',
-            };
-          default:
-            return {};
-        }
-      },
-
-      validate: {
-        name: isNotEmpty('Name is required'),
-        album: isNotEmpty('Album is required'),
-        artist: isNotEmpty('Artist is required'),
-        trackIndex: (value, values) => {
-          // Can be left blank
-          if (!value && value !== 0) {
-            return null;
-          }
-
-          const hasATrackNumber = !!values.trackOf;
-
-          if (hasATrackNumber) {
-            return isInRange(
-              { min: 1, max: values.trackOf },
-              `Must be between 1 and ${values.trackOf}`
-            )(value);
-          } else if (!!value) {
-            return `Must provide total tracks before setting track number`;
-          }
-        },
-        trackOf: (value) => {
-          if (!value && value !== 0) {
-            return null;
-          }
-
-          return value <= 0 ? 'Must be greater than 0' : null;
-        },
-      },
-    };
-  }
-
-  return config;
-};
-
-function getValueFromItem<T>(fieldName: string, item: MediaItemWithNodeId): T {
-  return (item as { [key: string]: any })[fieldName] ?? item.metadata[fieldName] ?? '';
-}
-
-const getFormDependentsConfig = (item: MediaItemWithNodeId): { [key: string]: string[] } => {
-  if (item.extension === 'mp3') {
-    return {
-      trackOf: ['trackIndex'],
-    };
-  }
-
-  return {};
 };

--- a/src/pages/edit/form/get-item-payload.ts
+++ b/src/pages/edit/form/get-item-payload.ts
@@ -1,0 +1,43 @@
+import { FILE_FIELDS, NUMBER_FIELDS } from './single-item-edit-form';
+
+type getItemPayloadArgs = {
+  values: { [key: string]: any };
+  mediaId: string;
+  nodeId: string;
+};
+
+type itemPayload = {
+  data: { mediaId: string; nodeId: string; change: { [key: string]: any } };
+  files: { fieldName: string; file: File }[];
+};
+
+export const getItemPayload = ({ values, mediaId, nodeId }: getItemPayloadArgs): itemPayload => {
+  const files = Object.keys(values).reduce<{ fieldName: string; file: File }[]>(
+    (acc, fieldName) => {
+      if (FILE_FIELDS.includes(fieldName)) {
+        const value = values[fieldName];
+        if (value) {
+          acc = [...acc, { fieldName, file: value }];
+        }
+      }
+
+      return acc;
+    },
+    []
+  );
+
+  const change = Object.entries(values).reduce<{ [key: string]: any }>((acc, [key, value]) => {
+    if (NUMBER_FIELDS.includes(key)) {
+      acc[key] = +value;
+    } else if (FILE_FIELDS.includes(key) && value) {
+      // Save images as the name of the field as that is what is being sent as part of the FormData
+      acc[key] = key;
+    } else {
+      acc[key] = value;
+    }
+
+    return acc;
+  }, {});
+
+  return { files, data: { mediaId, nodeId, change } };
+};

--- a/src/pages/edit/form/single-item-edit-form.tsx
+++ b/src/pages/edit/form/single-item-edit-form.tsx
@@ -1,0 +1,215 @@
+import { useMemo, useState } from 'react';
+import { IconAlertCircle } from '@tabler/icons-react';
+import { useNavigate } from 'react-router-dom';
+import { Button, Flex, Group } from '@mantine/core';
+import { isInRange, isNotEmpty, useForm, UseFormInput } from '@mantine/form';
+import { notifications } from '@mantine/notifications';
+import { usePollCompletion } from '@/hooks/use-poll-completion/use-poll-completion';
+import { changesetService } from '@/services/changeset/changeset-service';
+import { mediaService } from '@/services/media/media-service';
+import { EditItemForm } from './edit-item-form';
+import { getItemPayload } from './get-item-payload';
+
+export const NUMBER_FIELDS = ['trackOf', 'trackIndex'];
+export const FILE_FIELDS = ['art'];
+
+interface EditItemFormProps {
+  item: MediaItemWithNodeId;
+}
+
+export const SingleItemEditForm = ({ item }: EditItemFormProps) => {
+  const formConfig = useMemo(() => getFormConfig(item), [item]);
+  const [changesetId, setChangesetId] = useState<null | string>(null);
+  const navigate = useNavigate();
+
+  usePollCompletion({
+    queryCompletion: async () => {
+      if (!changesetId) return { complete: false };
+      try {
+        const changeset = await changesetService.getChangeset(changesetId);
+
+        if (changeset.status === 'complete') return { complete: true, success: true };
+        if (changeset.status === 'failed') return { complete: true };
+
+        return { complete: false };
+      } catch (e) {
+        return { complete: true, success: false };
+      }
+    },
+    onComplete(success) {
+      if (success) {
+        notifications.show({
+          title: 'Updated',
+          message: 'Successfully updated item',
+          autoClose: 2000,
+        });
+      } else {
+        notifications.show({
+          title: 'Failed to edit',
+          message: 'An error occured when trying to edit this item.',
+          autoClose: 5000,
+          color: 'red',
+          icon: <IconAlertCircle></IconAlertCircle>,
+        });
+      }
+
+      setChangesetId(null);
+    },
+    enabled: !!changesetId,
+  });
+
+  const handleSubmitForm = async (values: { [key: string]: any }) => {
+    const { id: mediaId, nodeId } = item;
+
+    const payload = getItemPayload({ values, nodeId, mediaId });
+
+    const { data: changes, files } = payload;
+
+    try {
+      const changeset = await mediaService.updateMedia([changes], files);
+      setChangesetId(changeset.id);
+
+      form.resetTouched();
+    } catch (e) {
+      notifications.show({
+        title: 'Failed to edit',
+        message: 'An error occured when trying to edit this item.',
+        autoClose: 5000,
+        color: 'red',
+        icon: <IconAlertCircle></IconAlertCircle>,
+      });
+    }
+  };
+
+  if (!formConfig) return <div>Cannot edit item with extenstion {item.extension}</div>;
+  const form = useForm(formConfig);
+
+  const dependencyMappingForMediaType = useMemo(() => getFormDependentsConfig(item), [item]);
+
+  return (
+    <Flex direction="column">
+      <EditItemForm
+        form={form}
+        dependentsConfig={dependencyMappingForMediaType}
+        onSubmit={handleSubmitForm}
+      />
+      <Group>
+        <Button mt="md" variant="subtle" onClick={() => navigate(-1)}>
+          Cancel
+        </Button>
+        <Button
+          mt="md"
+          disabled={!form.isValid() || !form.isTouched()}
+          loading={!!changesetId}
+          onClick={() => handleSubmitForm(form.getValues())}
+        >
+          Save
+        </Button>
+      </Group>
+    </Flex>
+  );
+};
+
+const getFormConfig = (item: MediaItemWithNodeId) => {
+  let config: UseFormInput<{ [key: string]: any }> | null = null;
+
+  if (item.extension === 'mp3') {
+    // TODO: add album art and start/end time
+    config = {
+      mode: 'uncontrolled',
+      validateInputOnChange: true,
+      initialValues: {
+        art: null,
+        name: getValueFromItem('name', item),
+        album: getValueFromItem('album', item),
+        artist: getValueFromItem('artist', item),
+        trackIndex: getValueFromItem('trackIndex', item) || '',
+        trackOf: getValueFromItem('trackOf', item) || '',
+      },
+
+      enhanceGetInputProps({ field: fieldName }) {
+        switch (fieldName) {
+          case 'art': {
+            return {
+              label: 'Album Art',
+              clearable: true,
+              accept: 'image/jpeg,image/jpg',
+              placeholder: 'Upload Album Art',
+            };
+          }
+          case 'name':
+            return {
+              label: 'Song Name',
+              withAsterisk: true,
+            };
+          case 'album':
+            return {
+              label: 'Album',
+              withAsterisk: true,
+            };
+          case 'artist':
+            return {
+              label: 'Artist',
+              withAsterisk: true,
+            };
+          case 'trackIndex':
+            return {
+              label: 'Track Number',
+            };
+          case 'trackOf':
+            return {
+              label: 'Total Tracks',
+            };
+          default:
+            return {};
+        }
+      },
+
+      validate: {
+        name: isNotEmpty('Name is required'),
+        album: isNotEmpty('Album is required'),
+        artist: isNotEmpty('Artist is required'),
+        trackIndex: (value, values) => {
+          // Can be left blank
+          if (!value && value !== 0) {
+            return null;
+          }
+
+          const hasATrackNumber = !!values.trackOf;
+
+          if (hasATrackNumber) {
+            return isInRange(
+              { min: 1, max: values.trackOf },
+              `Must be between 1 and ${values.trackOf}`
+            )(value);
+          } else if (!!value) {
+            return `Must provide total tracks before setting track number`;
+          }
+        },
+        trackOf: (value) => {
+          if (!value && value !== 0) {
+            return null;
+          }
+
+          return value <= 0 ? 'Must be greater than 0' : null;
+        },
+      },
+    };
+  }
+
+  return config;
+};
+
+function getValueFromItem<T>(fieldName: string, item: MediaItemWithNodeId): T {
+  return (item as { [key: string]: any })[fieldName] ?? item.metadata[fieldName] ?? '';
+}
+
+const getFormDependentsConfig = (item: MediaItemWithNodeId): { [key: string]: string[] } => {
+  if (item.extension === 'mp3') {
+    return {
+      trackOf: ['trackIndex'],
+    };
+  }
+
+  return {};
+};


### PR DESCRIPTION
In preparation for allowing multi item edits the edit flow was refactored as follows:

* Edit page now handles multiple ids in the query params -> Still only renders the single form
* Payload calculation was extracted to its own re-useable function
* Edit form was separated into 2 components. One smaller one where its only responsibility is to render the form fields and the other is to get the form from the item and handle submission and polling logic